### PR TITLE
ci: switch swift-tools-version through shell script

### DIFF
--- a/update_version.sh
+++ b/update_version.sh
@@ -25,6 +25,15 @@ else
   echo "ERROR !!!!"
 fi
 
+# Update swift-tools-version
+if [[ "$VERSION" == 9* ]]; then
+  sed "s/.*swift-tools-version.*/\/\/ swift-tools-version:5.5/" Package.swift > tmp.swift
+  mv tmp.swift Package.swift
+else
+  sed "s/.*swift-tools-version.*/\/\/ swift-tools-version:5.3/" Package.swift > tmp.swift
+  mv tmp.swift Package.swift
+fi
+
 # Update version
 sed "s#let version.*#let version = \"$VERSION\"#" Package.swift > tmp.swift
 mv tmp.swift Package.swift


### PR DESCRIPTION
> FYI to @serajahmad01 and @VMadiwalkar: for SDK 9.0 I had to bump up the swift-tools-version. For patches of lower SDK versions (e.g. 8.0.5) this has to be reverted. I am planning to do this [update_version.sh](https://github.com/SAP/cloud-sdk-ios/blob/main/update_version.sh) in a future PR but until that is available we have to be careful and change that manually whenever necessary.

This PR will ensure that update_version.sh shell script will adjust swift tools version accordingly.