### PR TITLE
docs: reference generic SAP contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For issues related to any of the referenced resources and binaries, please file 
 
 ## Contributing
 
-If you wish to make a contribution to the repository, please [submit a Pull Request](https://github.com/SAP/cloud-sdk-ios/pulls).  It will be reviewed by the maintainers, however, we cannot commit to merging all contributions.
+If you wish to make a contribution to the repository, please adhere to SAPs [contribution guidelines](https://github.com/SAP/.github/blob/main/CONTRIBUTING.md).
 
 ### Maintainers: Updating the package
 


### PR DESCRIPTION
According to Open Source Program Office (OSPO): as the repository https://github.com/sap/cloud-sdk-ios does not have a specific CONTRIBUTING.md, we must reference the generic one from our README in a Contributing section.