### PR TITLE
ci: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify-swift-package-binaryTargets:
     runs-on: ubuntu-latest

--- a/.github/workflows/spm-collection.yml
+++ b/.github/workflows/spm-collection.yml
@@ -11,6 +11,10 @@ on:
         required: true
         default: "true"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   generate-signed-collection:
     runs-on: macos-12


### PR DESCRIPTION
Add explicit GITHUB_TOKEN permissions to comply with security hardening measures for supply chain attack prevention.

- ci.yml: Set read-only permissions (contents: read) as the workflow only performs verification tasks
- spm-collection.yml: Set write permissions (contents: write, pull-requests: write) required for creating PRs via peter-evans/create-pull-request action

This change prepares the repository for the organization-wide switch to read-only default permissions scheduled for 27 May 2026.

Reference: CPAWGOSS-1209